### PR TITLE
Docker-based source build and Debian packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 *.exe
 *.out
 *.app
+
+# Packages
+*.deb

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,10 +13,7 @@ ENV PKG_VERSION="${WPA_SUPPLICANT_VER}-${PKG_RELEASE}mayfield${MAYFIELD_VER}"
 
 RUN apt-get update -qq \
   && apt-get install -yq \
-    autoconf \
-    automake \
     build-essential \
-    iptables-dev \
     libdbus-1-dev \
     libglib2.0-dev \
     libgnutls-dev \
@@ -25,12 +22,8 @@ RUN apt-get update -qq \
     libnl-3-dev \
     libreadline-dev \
     libssl-dev \
-    libtool \
-    openconnect \
-    openvpn \
     pkg-config \
     ruby-dev \
-    vpnc \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/*
 
@@ -46,9 +39,9 @@ RUN mkdir -p ${INSTALL_DIR} \
 
 # http://www.linuxfromscratch.org/blfs/view/svn/basicnet/wpa_supplicant.html
 RUN install --directory ${INSTALL_DIR}/usr/share/dbus-1/system-services/ \
-  && install --mode 0644 -D dbus/fi.epitest.hostap.WPASupplicant.service \
+  && install --mode 0644 dbus/fi.epitest.hostap.WPASupplicant.service \
       --target-directory ${INSTALL_DIR}/usr/share/dbus-1/system-services/ \
-  && install --mode 0644 -D dbus/fi.w1.wpa_supplicant1.service \
+  && install --mode 0644 dbus/fi.w1.wpa_supplicant1.service \
       --target-directory ${INSTALL_DIR}/usr/share/dbus-1/system-services/ \
   && install --mode 0644 -D dbus/dbus-wpa_supplicant.conf \
       ${INSTALL_DIR}/etc/dbus-1/system.d/wpa_supplicant.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,74 @@
+FROM mayfieldrobotics/ubuntu:14.04
+
+ENV DEBIAN_FRONTEND="noninteractive" \
+    TERM="xterm"
+
+ARG WPA_SUPPLICANT_VER
+ARG PKG_RELEASE
+ARG MAYFIELD_VER
+ARG ARTIFACTS_DIR
+
+ENV INSTALL_DIR="/tmp/installdir"
+ENV PKG_VERSION="${WPA_SUPPLICANT_VER}-${PKG_RELEASE}mayfield${MAYFIELD_VER}"
+
+RUN apt-get update -qq \
+  && apt-get install -yq \
+    autoconf \
+    automake \
+    build-essential \
+    iptables-dev \
+    libdbus-1-dev \
+    libglib2.0-dev \
+    libgnutls-dev \
+    libncurses5-dev \
+    libnl-genl-3-dev \
+    libnl-3-dev \
+    libreadline-dev \
+    libssl-dev \
+    libtool \
+    openconnect \
+    openvpn \
+    pkg-config \
+    ruby-dev \
+    vpnc \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+RUN gem install --no-ri --no-rdoc fpm
+
+COPY . /root/wpa_supplicant/
+
+WORKDIR /root/wpa_supplicant/wpa_supplicant
+
+RUN mkdir -p ${INSTALL_DIR} \
+  && make BINDIR=/usr/sbin LIBDIR=/usr/lib \
+  && make install BINDIR=/usr/sbin LIBDIR=/usr/lib DESTDIR=${INSTALL_DIR}
+
+# http://www.linuxfromscratch.org/blfs/view/svn/basicnet/wpa_supplicant.html
+RUN install --directory ${INSTALL_DIR}/usr/share/dbus-1/system-services/ \
+  && install --mode 0644 -D dbus/fi.epitest.hostap.WPASupplicant.service \
+      --target-directory ${INSTALL_DIR}/usr/share/dbus-1/system-services/ \
+  && install --mode 0644 -D dbus/fi.w1.wpa_supplicant1.service \
+      --target-directory ${INSTALL_DIR}/usr/share/dbus-1/system-services/
+
+# NOTE: The dependencies below were copied from wpasupplicant 2.1-0ubuntu1.4
+RUN fpm \
+  --input-type dir \
+  --chdir ${INSTALL_DIR} \
+  --output-type deb \
+  --architecture native \
+  --name wpasupplicant \
+  --version ${PKG_VERSION} \
+  --description "Client support for WPA and WPA2 (IEEE 802.11i)." \
+  --depends "libc6 (>= 2.15), libdbus-1-3 (>= 1.1.4), libnl-3-200 (>= 3.2.7), \
+             libnl-genl-3-200 (>= 3.2.7), libpcsclite1 (>= 1.0.0), \
+             libreadline5 (>= 5.2), libssl1.0.0 (>= 1.0.1), \
+             lsb-base (>= 3.0-6), adduser, initscripts (>= 2.88dsf-13.3)" \
+  --license "BSD" \
+  --vendor "Mayfield Robotics" \
+  --maintainer "Spyros Maniatopoulos <spyros@mayfieldrobotics.com>" \
+  --url "https://github.com/mayfieldrobotics/wpa_supplicant" \
+  .
+
+RUN mkdir -p ${ARTIFACTS_DIR} \
+  && mv *.deb ${ARTIFACTS_DIR}

--- a/Dockerfile
+++ b/Dockerfile
@@ -49,7 +49,9 @@ RUN install --directory ${INSTALL_DIR}/usr/share/dbus-1/system-services/ \
   && install --mode 0644 -D dbus/fi.epitest.hostap.WPASupplicant.service \
       --target-directory ${INSTALL_DIR}/usr/share/dbus-1/system-services/ \
   && install --mode 0644 -D dbus/fi.w1.wpa_supplicant1.service \
-      --target-directory ${INSTALL_DIR}/usr/share/dbus-1/system-services/
+      --target-directory ${INSTALL_DIR}/usr/share/dbus-1/system-services/ \
+  && install --mode 0644 -D dbus/dbus-wpa_supplicant.conf \
+      ${INSTALL_DIR}/etc/dbus-1/system.d/wpa_supplicant.conf
 
 # NOTE: The dependencies below were copied from wpasupplicant 2.1-0ubuntu1.4
 RUN fpm \

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env sh
+
+set -eux
+
+# Build a Docker image that compiles and packages WPA Supplicant
+DOCKER_IMAGE="wpasupplicant-build"
+DOCKER_ARTIFACTS="/root/artifacts"
+
+docker build \
+  --build-arg WPA_SUPPLICANT_VER="1.33" \
+  --build-arg PKG_RELEASE="0" \
+  --build-arg MAYFIELD_VER="0" \
+  --build-arg ARTIFACTS_DIR=${DOCKER_ARTIFACTS} \
+  --tag ${DOCKER_IMAGE} \
+  .
+
+# Extract the Debian packages from the Docker image
+DOCKER_CONTAINER="wpasupplicant-artifacts"
+LOCAL_ARTIFACTS=$(basename ${DOCKER_ARTIFACTS})
+
+mkdir -p ${LOCAL_ARTIFACTS}
+rm -f ${LOCAL_ARTIFACTS}/*.deb
+
+docker create --name ${DOCKER_CONTAINER} ${DOCKER_IMAGE}
+docker cp "${DOCKER_CONTAINER}:${DOCKER_ARTIFACTS}" "./"
+docker stop ${DOCKER_CONTAINER} && docker rm ${DOCKER_CONTAINER}
+
+# Inspect the Debian packages
+dpkg-deb --info ${LOCAL_ARTIFACTS}/wpasupplicant_*
+dpkg-deb --contents ${LOCAL_ARTIFACTS}/wpasupplicant_*


### PR DESCRIPTION
~~Work in Progress :construction:~~

### Usage

```bash
./docker_build.sh
```

### Debian package contents

```bash
dpkg-deb --contents artifacts/wpasupplicant_1.33-0mayfield0_amd64.deb
drwxr-xr-x 0/0               0 2017-04-25 13:51 ./
drwxr-xr-x 0/0               0 2017-04-25 13:51 ./usr/
drwxr-xr-x 0/0               0 2017-04-25 13:51 ./usr/sbin/
-rwxr-xr-x 0/0          249702 2017-04-25 13:51 ./usr/sbin/wpa_passphrase
-rwxr-xr-x 0/0          383339 2017-04-25 13:51 ./usr/sbin/wpa_cli
-rwxr-xr-x 0/0         6942128 2017-04-25 13:51 ./usr/sbin/wpa_supplicant
drwxr-xr-x 0/0               0 2017-04-25 13:51 ./usr/share/
drwxr-xr-x 0/0               0 2017-04-25 13:51 ./usr/share/doc/
drwxr-xr-x 0/0               0 2017-04-25 13:51 ./usr/share/doc/wpasupplicant/
-rw-r--r-- 0/0             170 2017-04-25 13:51 ./usr/share/doc/wpasupplicant/changelog.gz
drwxr-xr-x 0/0               0 2017-04-25 13:51 ./usr/share/dbus-1/
drwxr-xr-x 0/0               0 2017-04-25 13:51 ./usr/share/dbus-1/system-services/
-rw-r--r-- 0/0             124 2017-04-25 13:51 ./usr/share/dbus-1/system-services/fi.w1.wpa_supplicant1.service
-rw-r--r-- 0/0             134 2017-04-25 13:51 ./usr/share/dbus-1/system-services/fi.epitest.hostap.WPASupplicant.service
drwxr-xr-x 0/0               0 2017-04-25 13:51 ./etc/
drwxr-xr-x 0/0               0 2017-04-25 13:51 ./etc/dbus-1/
drwxr-xr-x 0/0               0 2017-04-25 13:51 ./etc/dbus-1/system.d/
-rw-r--r-- 0/0            1096 2017-04-25 13:51 ./etc/dbus-1/system.d/wpa_supplicant.conf
```
