### PR TITLE
Set WPA Supplicant version to 2.6

### DIFF
--- a/docker_build.sh
+++ b/docker_build.sh
@@ -7,7 +7,7 @@ DOCKER_IMAGE="wpasupplicant-build"
 DOCKER_ARTIFACTS="/root/artifacts"
 
 docker build \
-  --build-arg WPA_SUPPLICANT_VER="1.33" \
+  --build-arg WPA_SUPPLICANT_VER="2.6" \
   --build-arg PKG_RELEASE="0" \
   --build-arg MAYFIELD_VER="0" \
   --build-arg ARTIFACTS_DIR=${DOCKER_ARTIFACTS} \


### PR DESCRIPTION
That would have been a fun one to debug ... I noticed thanks to:

```
dpkg: warning: downgrading wpasupplicant from 2.1-0ubuntu1.4 to 1.33-0mayfield0
```

`1.33` was the version of ConnMan. Too much copy-pasting from one script to the other :grin: 

Now we have:

```
odroid@p2bed1:~$ apt-cache show wpasupplicant
Package: wpasupplicant
Status: install ok installed
Priority: extra
Section: default
Installed-Size: 7398
Maintainer: Spyros Maniatopoulos <spyros@mayfieldrobotics.com>
Architecture: amd64
Version: 2.6-0mayfield0
Depends: libc6 (>= 2.15), libdbus-1-3 (>= 1.1.4), libnl-3-200 (>= 3.2.7), libnl-genl-3-200 (>= 3.2.7), libpcsclite1 (>= 1.0.0), libreadline5 (>= 5.2), libssl1.0.0 (>= 1.0.1), lsb-base (>= 3.0-6), adduser, initscripts (>= 2.88dsf-13.3)
Conffiles:
 /etc/dbus-1/system.d/wpa_supplicant.conf a700637c8eb19e4879c8eb754d464ff4
 /etc/wpa_supplicant/action_wpa.sh 5269e292cd68ebf9698e26d3026e817e obsolete
 /etc/wpa_supplicant/functions.sh 550c42ecf41ce2bf299383c50dacdf1c obsolete
 /etc/wpa_supplicant/ifupdown.sh 4c82dbf7e1d8c5ddd70e40b9665cfeee obsolete
Description: Client support for WPA and WPA2 (IEEE 802.11i).
Description-md5: 6de61cabf740c6601d1993d06f92a11b
License: BSD
Vendor: Mayfield Robotics
Homepage: https://github.com/mayfieldrobotics/wpa_supplicant
```