### PR TITLE
Rename Debian package to wpasupplicant-mf

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,13 +3,13 @@ FROM mayfieldrobotics/ubuntu:14.04
 ENV DEBIAN_FRONTEND="noninteractive" \
     TERM="xterm"
 
-ARG WPA_SUPPLICANT_VER
+ARG PKG_NAME
+ARG SRC_VERSION
 ARG PKG_RELEASE
-ARG MAYFIELD_VER
 ARG ARTIFACTS_DIR
 
 ENV INSTALL_DIR="/tmp/installdir"
-ENV PKG_VERSION="${WPA_SUPPLICANT_VER}-${PKG_RELEASE}mayfield${MAYFIELD_VER}"
+ENV PKG_VERSION="${SRC_VERSION}-${PKG_RELEASE}"
 
 RUN apt-get update -qq \
   && apt-get install -yq \
@@ -52,13 +52,15 @@ RUN fpm \
   --chdir ${INSTALL_DIR} \
   --output-type deb \
   --architecture native \
-  --name wpasupplicant \
+  --name ${PKG_NAME} \
   --version ${PKG_VERSION} \
   --description "Client support for WPA and WPA2 (IEEE 802.11i)." \
   --depends "libc6 (>= 2.15), libdbus-1-3 (>= 1.1.4), libnl-3-200 (>= 3.2.7), \
              libnl-genl-3-200 (>= 3.2.7), libpcsclite1 (>= 1.0.0), \
              libreadline5 (>= 5.2), libssl1.0.0 (>= 1.0.1), \
              lsb-base (>= 3.0-6), adduser, initscripts (>= 2.88dsf-13.3)" \
+  --conflicts wpasupplicant \
+  --provides wpasupplicant \
   --license "BSD" \
   --vendor "Mayfield Robotics" \
   --maintainer "Spyros Maniatopoulos <spyros@mayfieldrobotics.com>" \

--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,7 @@ RUN fpm \
              lsb-base (>= 3.0-6), adduser, initscripts (>= 2.88dsf-13.3)" \
   --conflicts wpasupplicant \
   --provides wpasupplicant \
+  --replaces wpasupplicant \
   --license "BSD" \
   --vendor "Mayfield Robotics" \
   --maintainer "Spyros Maniatopoulos <spyros@mayfieldrobotics.com>" \

--- a/docker_build.sh
+++ b/docker_build.sh
@@ -2,14 +2,19 @@
 
 set -eux
 
+# Debian package metadata
+PKG_NAME="wpasupplicant-mf"
+SRC_VERSION="2.6"
+PKG_RELEASE="0"
+
 # Build a Docker image that compiles and packages WPA Supplicant
 DOCKER_IMAGE="wpasupplicant-build"
 DOCKER_ARTIFACTS="/root/artifacts"
 
 docker build \
-  --build-arg WPA_SUPPLICANT_VER="2.6" \
-  --build-arg PKG_RELEASE="0" \
-  --build-arg MAYFIELD_VER="0" \
+  --build-arg PKG_NAME=${PKG_NAME} \
+  --build-arg SRC_VERSION=${SRC_VERSION} \
+  --build-arg PKG_RELEASE=${PKG_RELEASE} \
   --build-arg ARTIFACTS_DIR=${DOCKER_ARTIFACTS} \
   --tag ${DOCKER_IMAGE} \
   .
@@ -26,5 +31,5 @@ docker cp "${DOCKER_CONTAINER}:${DOCKER_ARTIFACTS}" "./"
 docker stop ${DOCKER_CONTAINER} && docker rm ${DOCKER_CONTAINER}
 
 # Inspect the Debian packages
-dpkg-deb --info ${LOCAL_ARTIFACTS}/wpasupplicant_*
-dpkg-deb --contents ${LOCAL_ARTIFACTS}/wpasupplicant_*
+dpkg-deb --info ${LOCAL_ARTIFACTS}/${PKG_NAME}_*
+dpkg-deb --contents ${LOCAL_ARTIFACTS}/${PKG_NAME}_*


### PR DESCRIPTION
Give our Debian package a different name, `wpasupplicant-mf`, in order to prevent non-robot machines that use our apt repo (such as our dev laptops) from accidentally upgrading their `wpasupplicant` due to its version now being higher. This package is only meant for robots :robot: 

Excerpt from installing this on my board:

```bash
$ sudo dpkg -i wpasupplicant-mf_2.6-0_amd64.deb 
dpkg: considering removing wpasupplicant in favour of wpasupplicant-mf ...
dpkg: yes, will remove wpasupplicant in favour of wpasupplicant-mf
(Reading database ... 107011 files and directories currently installed.)
Preparing to unpack wpasupplicant-mf_2.6-0_amd64.deb ...
Unpacking wpasupplicant-mf (2.6-0) ...
Setting up wpasupplicant-mf (2.6-0) ...
Installing new version of config file /etc/dbus-1/system.d/wpa_supplicant.conf ...
Processing triggers for man-db (2.6.7.1-1ubuntu1) ...

$ apt-cache policy wpasupplicant
wpasupplicant:
  Installed: (none)
  Candidate: (none)
  Version table:
     2.1-0ubuntu1.4 0
        100 /var/lib/dpkg/status

$ apt-cache policy wpasupplicant-mf
wpasupplicant-mf:
  Installed: 2.6-0
  Candidate: 2.6-0
  Version table:
 *** 2.6-0 0
        100 /var/lib/dpkg/status

$ wpa_supplicant -v
wpa_supplicant v2.6
Copyright (c) 2003-2016, Jouni Malinen <j@w1.fi> and contributors
```